### PR TITLE
Annotation keying mistake

### DIFF
--- a/externs.js
+++ b/externs.js
@@ -24,8 +24,8 @@ React.createClass = function(specification) {};
 React.createFactory = function(reactClass) {};
 
 /**
- * @param {ReactComponent|DOMElement} componentOrElement
- * @return {DOMElement} The root node of this element.
+ * @param {React.ReactComponent|Element} componentOrElement
+ * @return {Element} The root node of this element.
  */
 React.findDOMNode = function(componentOrElement) {};
 


### PR DESCRIPTION
Mistake with params annotation

```
>> bower_components/react-externs/externs.js:27: WARNING - Bad type annotation. Unknown type ReactComponent
>>  * @param {ReactComponent|DOMElement} componentOrElement
>>            ^
>> 
>> bower_components/react-externs/externs.js:27: WARNING - Bad type annotation. Unknown type DOMElement
>>  * @param {ReactComponent|DOMElement} componentOrElement
>>                           ^
>> 
>> bower_components/react-externs/externs.js:28: WARNING - Bad type annotation. Unknown type DOMElement
>>  * @return {DOMElement} The root node of this element.
>>             ^
>> 
>> 0 error(s), 3 warning(s), 96.6% typed
```