### PR TITLE
fix a type of React.PropTypes.instanceOf

### DIFF
--- a/externs.js
+++ b/externs.js
@@ -1579,7 +1579,7 @@ React.PropTypes = {
    */
   oneOfType: function(typeCheckers) {},
   /**
-   * @param {function (new:Object, ...*): ?} expectedClass
+   * @param {function (new:Object, ...)} expectedClass
    * @return {React.ChainableTypeChecker}
    */
   instanceOf: function(expectedClass) {},


### PR DESCRIPTION
`function(...*)` can not any arguments.
It should be `function(...?)` or `function(...)`.

```
../jsx/login.js:22: ERROR - actual parameter 1 of React.PropTypes.instanceOf does not match formal parameter
found   : function (new:LoginStore, string, string): undefined
required: function (new:Object, ...*): ?
        store: React.PropTypes.instanceOf(LoginStore).isRequired,
```

Also the return type is useless for a constructor.